### PR TITLE
16. System interceptor - add interceptor for injecting db component into context

### DIFF
--- a/src/dev/dev.clj
+++ b/src/dev/dev.clj
@@ -31,4 +31,7 @@
   (keys cr/system)
 ;; => (:config :api-server :database)
 
+  ;; let's look at :api-server
+  (:api-server cr/system)
+
   .)


### PR DESCRIPTION
Interceptor is simply a map with keys :name, :enter, :leave, :error - here we only use :enter.
Notice the usage of io.pedestal.interceptor/interceptor helper function.
```
(defn inject-system [system]
  (interceptor/interceptor
   {:name ::inject-system
    :enter (fn [ctx]
             ;; let's just add our whole system to the :request key
             (update ctx :request merge system))}))
```