### PR TITLE
20 Add db-interceptor.

### DIFF
--- a/src/main/cheffy/components/api_server.clj
+++ b/src/main/cheffy/components/api_server.clj
@@ -1,6 +1,7 @@
 (ns cheffy.components.api-server
   (:require
    [cheffy.routes :as routes]
+   [cheffy.interceptors :as interceptors]
    [com.stuartsierra.component :as component]
    [io.pedestal.http :as http]
    [io.pedestal.interceptor :as interceptor]))
@@ -39,7 +40,8 @@
   (-> service-map
       (assoc ::http/routes routes/table-routes)
       ;; here we add our interceptor to the interceptor chain to include the db component
-      (cheffy-interceptors [(inject-system {:system/database database})])
+      (cheffy-interceptors [(inject-system {:system/database database})
+                            interceptors/db-interceptor])
       http/create-server
       http/start))
 

--- a/src/main/cheffy/components/database.clj
+++ b/src/main/cheffy/components/database.clj
@@ -9,8 +9,9 @@
             [clojure.edn :as edn]))
 
 
-(defn ident-has-attr? [db ident attr]
-  ;; check if accounts exist already
+(defn ident-has-attr?
+  "Checks whether there's a db entity with with given id and attribute."
+  [db ident attr]
   (contains? (d/pull db {:eid ident :selector '[*]})
              attr))
 

--- a/src/main/cheffy/interceptors.clj
+++ b/src/main/cheffy/interceptors.clj
@@ -1,0 +1,13 @@
+(ns cheffy.interceptors
+  (:require [datomic.client.api :as d]
+            [io.pedestal.interceptor :as interceptor]))
+
+(def db-interceptor
+  (interceptor/interceptor
+   {:name ::db-interceptor
+    :enter (fn [ctx]
+             ;; grab the connection injected by the system interceptor (see `cheffy.components.api-server/cheffy-interceptors`),
+             ;; create the db and add it to the context
+             (let [conn (get-in ctx [:request :system/database :conn])
+                   db (d/db conn)]
+               (assoc-in ctx [:request :system/database :db] db)))}))

--- a/src/main/cheffy/routes.clj
+++ b/src/main/cheffy/routes.clj
@@ -3,6 +3,7 @@
 
 ;; add some more routes
 (defn list-recipes [request]
+  (prn "DEBUG:: [request] " [request])
   {:status 200
    :body "list recipes"})
 


### PR DESCRIPTION
To avoid making new database for every interaction,
we create it just once for every request and store it in the context.
We do this via Pedestal's interceptor.