### PR TITLE
23, 24, 25:  Refactor list-recipes-response, create-recipe and transit format.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,9 @@
         io.pedestal/pedestal.route {:mvn/version "0.5.10"}
         io.pedestal/pedestal.jetty {:mvn/version "0.5.10"}
         org.clojure/tools.analyzer {:mvn/version "1.1.0"}
-        com.stuartsierra/component {:mvn/version "1.1.0"}}
+        com.stuartsierra/component {:mvn/version "1.1.0"}
+        ;; https://github.com/cognitect/transit-clj
+        com.cognitect/transit-clj {:mvn/version "1.0.329"}}
 
  :aliases {:dev {:extra-paths ["src/dev"]
                  :extra-deps {com.datomic/dev-local {:mvn/version "1.0.243"}

--- a/src/dev/dev.clj
+++ b/src/dev/dev.clj
@@ -1,7 +1,8 @@
 (ns dev
   (:require
-   [clojure.edn :as end]
    [cheffy.server :as server]
+   [cheffy.util.transit :refer [transit-read transit-write]]
+   [clojure.edn :as end]
    [com.stuartsierra.component.repl :as cr]
    [datomic.client.api :as d]
    [io.pedestal.http :as http]
@@ -134,9 +135,38 @@
        :get "/recipes"
        ;; account-id is taken from seed.edn
        :headers {"Authorization"  "auth|5fbf7db6271d5e0076903601"})
-      :headers
+      :body
       )
 
 
+  .)
+
+;; Lesson 25: create recipe
+
+(comment
+  (restart-dev)
+
+  (-> (pt/response-for
+       (-> cr/system :api-server :service ::http/service-fn)
+       :post "/recipes"
+         ;; account-id is taken from seed.edn
+       :headers {"Authorization"  "auth|5fbf7db6271d5e0076903601"
+                 "Content-Type" "application/transit+json"}
+       :body (transit-write {:name "my transit recipe"
+                             :public true
+                             :prep-time 30
+                             :img "https://github.com/clojure.png"})))
+  ;; => {:status 201,
+  ;;     :body "",
+  ;;     :headers
+  ;;     {"X-Frame-Options" "DENY",
+  ;;      "X-XSS-Protection" "1; mode=block",
+  ;;      "X-Download-Options" "noopen",
+  ;;      "Location" "/recipes/cd716f87-c59c-4e63-b875-d06d654ce06c",
+  ;;      "Strict-Transport-Security" "max-age=31536000; includeSubdomains",
+  ;;      "X-Permitted-Cross-Domain-Policies" "none",
+  ;;      "X-Content-Type-Options" "nosniff",
+  ;;      "Content-Security-Policy"
+  ;;      "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"}}
   .)
 

--- a/src/dev/dev.clj
+++ b/src/dev/dev.clj
@@ -134,7 +134,7 @@
        :get "/recipes"
        ;; account-id is taken from seed.edn
        :headers {"Authorization"  "auth|5fbf7db6271d5e0076903601"})
-      :body
+      :headers
       )
 
 

--- a/src/main/cheffy/components/api_server.clj
+++ b/src/main/cheffy/components/api_server.clj
@@ -41,7 +41,9 @@
       (assoc ::http/routes routes/table-routes)
       ;; here we add our interceptor to the interceptor chain to include the db component
       (cheffy-interceptors [(inject-system {:system/database database})
-                            interceptors/db-interceptor])
+                            interceptors/db-interceptor
+                            ;; convert response to transit format
+                            http/transit-body])
       http/create-server
       http/start))
 

--- a/src/main/cheffy/components/api_server.clj
+++ b/src/main/cheffy/components/api_server.clj
@@ -4,6 +4,7 @@
    [cheffy.interceptors :as interceptors]
    [com.stuartsierra.component :as component]
    [io.pedestal.http :as http]
+   [io.pedestal.http.body-params :as bp]
    [io.pedestal.interceptor :as interceptor]))
 
 (defn dev? [{:keys [env] :as _service-map}]
@@ -42,6 +43,7 @@
       ;; here we add our interceptor to the interceptor chain to include the db component
       (cheffy-interceptors [(inject-system {:system/database database})
                             interceptors/db-interceptor
+                            (bp/body-params)
                             ;; convert response to transit format
                             http/transit-body])
       http/create-server

--- a/src/main/cheffy/recipes.clj
+++ b/src/main/cheffy/recipes.clj
@@ -3,7 +3,8 @@
    [datomic.client.api :as d]
    [cheffy.interceptors :as interceptors]
    [cheshire.core :as json]
-   [ring.util.response :refer [response]]))
+   [ring.util.response :refer [response]]
+   [io.pedestal.http :as http]))
 
 (defn- query-result->recipe [[q-result]]
   (-> q-result
@@ -63,7 +64,9 @@
 
 ;; TODO juraj: is this really needed?
 ;; the interceptor seems to work just fine if I keep it in api-server
-(def list-recipes [interceptors/db-interceptor #'list-recipes-response])
+(def list-recipes [interceptors/db-interceptor
+                   http/transit-body
+                   #'list-recipes-response])
 
 (defn upsert-recipe-response [request]
   {:status 200

--- a/src/main/cheffy/routes.clj
+++ b/src/main/cheffy/routes.clj
@@ -13,7 +13,7 @@
    #{{:app-name :cheffy ::http/scheme :http ::http/host "localhost"}
      ;; now define the routes themselves
      ["/recipes" :get #'recipes/list-recipes-response :route-name :list-recipes]
-     ["/recipes" :post #'recipes/upsert-recipe-response :route-name :create-recipe]
+     ["/recipes" :post #'recipes/create-recipe-response :route-name :create-recipe]
      ["/recipes/:recipe-id" :put #'recipes/update-recipe-response :route-name :update-recipe]}))
 ;; inspect `table-routes` again and notice `:path-params`:
 ;;     :path-params [:recipe-id]

--- a/src/main/cheffy/util/transit.clj
+++ b/src/main/cheffy/util/transit.clj
@@ -1,0 +1,31 @@
+(ns cheffy.util.transit
+  "Helper functions for (de-)serializaing transit encoded data.
+  See https://github.com/cognitect/transit-clj"
+  (:require
+   [cognitect.transit :as transit])
+  (:import (java.io ByteArrayInputStream
+                    ByteArrayOutputStream)))
+
+;;; transit-write and transit-read functions introduced in Lesson 25:
+;;; https://www.jacekschae.com/view/courses/learn-pedestal-pro/1366483-recipes/4306647-25-transit
+
+(defn transit-write
+  "Serialize given object to transit encoded in JSON."
+  [obj]
+  (let [out (ByteArrayOutputStream.)]
+    (transit/write (transit/writer out :json) obj)
+    (.toString out)))
+(println (transit-write {:name "Juraj" :age 36}))
+;; prints: ["^ ","~:name","Juraj","~:age",36]
+
+(defn transit-read
+  "Deserialized string representing json-encoded transit data
+  intoa proper Clojure object."
+  [json-string]
+  (let [in (ByteArrayInputStream. (.getBytes json-string))]
+    (transit/read (transit/reader in :json))))
+
+(-> {:name "Juraj" :age 36}
+    transit-write
+    transit-read)
+;; => {:name "Juraj", :age 36}


### PR DESCRIPTION
This tries to use http/transit-body interceptor
to automatically convert the response to Transit format,
but it doesn't work for some reason.
The response's content-type is still "text/plain".