### PR TITLE
29-32. Recipe CRUD operations using interceptors.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,10 @@
         org.clojure/tools.analyzer {:mvn/version "1.1.0"}
         com.stuartsierra/component {:mvn/version "1.1.0"}
         ;; https://github.com/cognitect/transit-clj
-        com.cognitect/transit-clj {:mvn/version "1.0.329"}}
+        com.cognitect/transit-clj {:mvn/version "1.0.329"}
+        ;; for easy logging to stdout https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
+        org.slf4j/slf4j-simple {:mvn/version "1.7.36"}
+        }
 
  :aliases {:dev {:extra-paths ["src/dev"]
                  :extra-deps {com.datomic/dev-local {:mvn/version "1.0.243"}

--- a/src/main/cheffy/interceptors.clj
+++ b/src/main/cheffy/interceptors.clj
@@ -1,16 +1,73 @@
 (ns cheffy.interceptors
   (:require [datomic.client.api :as d]
-            [io.pedestal.interceptor :as interceptor]))
+            [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.log :as log]))
+
+(def conn-path [:request :system/database :conn])
+(def db-path [:request :system/database :db])
+
+(defn connection [ctx]
+  (get-in ctx conn-path))
+
+(defn database [ctx]
+  (get-in ctx db-path))
 
 (defn- inject-db [ctx]
   ;; grab the connection injected by the system interceptor (see `cheffy.components.api-server/cheffy-interceptors`),
   ;; create the db and add it to the context
-  (let [conn (get-in ctx [:request :system/database :conn])
-        db (d/db conn)]
+  (let [db (d/db (connection ctx))]
     (println "Adding current db value to the request context")
-    (assoc-in ctx [:request :system/database :db] db)))
+    (assoc-in ctx db-path db)))
 
 (def db-interceptor
   (interceptor/interceptor
    {:name ::db-interceptor
     :enter inject-db}))
+
+(defn- transact!
+  [{:keys [tx-data] :as ctx}]
+  (log/debug :transact tx-data)
+  #_(def my-ctx ctx)
+  (when-let [result (some->> tx-data (d/transact (connection ctx)))] 
+    (log/trace :tx-result result)
+    (assoc ctx :tx-result result)))
+
+(defn- query!
+  [{:keys [q-data] :as ctx}]
+  (log/debug :q-data q-data :database (database ctx))
+  (when-let [result (and q-data (d/q (update q-data :args #(into [(database ctx)] %))))]
+    ;; add the database as the first of `:args`
+    (log/trace :q-result result)
+    (assoc ctx :q-result result)))
+
+(def transact-interceptor
+  (interceptor/interceptor
+   {:name ::transact-interceptor
+    :enter transact!}))
+
+(def query-interceptor
+  (interceptor/interceptor
+   {:name ::query-interceptor
+    :enter query!}))
+
+(comment
+
+  ;; DOesn't work for some reason
+  ;;1. Unhandled clojure.lang.ExceptionInfo
+  ;; :db.error/invalid-data-source Nil or missing data source. Did you forget to pass a database
+  ;; argument?
+  ;; {:cognitect.anomalies/category :cognitect.anomalies/incorrect,
+  ;;  :cognitect.anomalies/message
+  ;;  "Nil or missing data source. Did you forget to pass a database argument?",
+  ;;  :input nil,
+  ;;  :db/error :db.error/invalid-data-source}
+  #_(let [db (d/db (get-in com.stuartsierra.component.repl/system [:database :conn]))]
+    (query! {:q-data {:query '[:find (pull ?e pattern)
+                               :in $ ?recipe-id pattern
+                               :where [?e :recipe/recipe-id ?recipe-id]],
+                      :args [db
+
+                             #uuid "df3fc518-ae36-4fb0-a63a-58636bd99a26"
+                             [:recipe/recipe-id :recipe/prep-time :recipe/display-name :recipe/image-url :recipe/public? :account/_favorite-recipes #:recipe{:owner [:account/account-id :account/display-name]} #:recipe{:steps [:step/step-id :step/description :step/sort-order]} #:recipe{:ingredients [:ingredient/ingredient-id :ingredient/display-name :ingredient/amount :ingredient/measure :ingredient/sort-order]}]]}}))
+
+  .)

--- a/src/main/cheffy/recipes_with_interceptors.clj
+++ b/src/main/cheffy/recipes_with_interceptors.clj
@@ -1,0 +1,176 @@
+(ns cheffy.recipes-with-interceptors
+  "This is a different version of `cheffy.recipes` ns
+  using interceptors heavily to abstract away common behavior like db queries/transactions.
+  See also `cheffy.interceptors/transact-interceptor` and friends.
+
+  Note on debugging: Unfortunately, vars cannot be passed in as interceptor functions
+  because there's a validation inside Pedestal that prevents that.
+  This really hampers debugging because functions' values are captured at the time the interceptors
+  are defined and are thus hard to refresh (impossible with cider debugger?)"
+  (:require
+   [datomic.client.api :as d]
+   [cheffy.interceptors :as interceptors]
+   [cheshire.core :as json]
+   [ring.util.response :as response]
+   [io.pedestal.http :as http]
+   [io.pedestal.interceptor :as interceptor]
+   ;; Note: there's also `middleware` function but that works on request and response respectively
+   ;; - it doesn't have access to the whole context
+   [io.pedestal.interceptor.helpers :refer [around]]))
+
+;; see shownotes for the episode: https://www.jacekschae.com/view/courses/learn-pedestal-pro/1366483-recipes/4269943-22-list-recipes
+;; the output of our query will comply to this pattern
+(def recipe-pattern [:recipe/recipe-id
+                     :recipe/prep-time
+                     :recipe/display-name
+                     :recipe/image-url
+                     :recipe/public?
+                     ;; Notice the reverse lookup with underscore: https://docs.datomic.com/cloud/query/query-pull.html#reverse-lookup
+                     :account/_favorite-recipes
+                     {:recipe/owner
+                      [:account/account-id
+                       :account/display-name]}
+                     {:recipe/steps
+                      [:step/step-id
+                       :step/description
+                       :step/sort-order]}
+                     {:recipe/ingredients
+                      [:ingredient/ingredient-id
+                       :ingredient/display-name
+                       :ingredient/amount
+                       :ingredient/measure
+                       :ingredient/sort-order]}])
+
+(defn- query-result->recipe [[q-result]]
+  (-> q-result
+      (assoc :favorite-count (count (:account/_favorite_recipes q-result)))
+      ;; now dissoc the key that we do not want to expose
+      (dissoc :account/_favorite-recipes)))
+
+(defn- query-recipes [db account-id]
+  (let [;; notice that `pull` is a required symbol/function;
+        ;; instead is a special syntax recognized by datomic
+        public-recipes (d/q '[:find (pull ?e pattern)
+                              :in $ pattern
+                              :where [?e :recipe/public? true]]
+
+                            db recipe-pattern)]
+    (cond-> {:public (mapv query-result->recipe public-recipes)}
+      account-id (merge
+                  {:drafts (mapv query-result->recipe
+                                 (d/q '[:find (pull ?e pattern)
+                                        :in $ ?account-id pattern
+                                        :where
+                                        [?owner :account/account-id ?account-id]
+                                        [?e :recipe/owner ?owner]
+                                        [?e :recipe/public? false]]
+                                      db account-id recipe-pattern))}))))
+
+(defn list-recipes-response [{:keys [system/database] :as request}]
+  #_(prn "DEBUG:: [request] " [request])
+  (let [db (:db database)
+        ;; For now, a really stupid authentication mechanism will work - just pass account id in the Authorization header
+        ;; - see response-for call in dev.clj
+        account-id (get-in request [:headers "authorization"])
+        recipes (query-recipes db account-id)]
+    (-> recipes json/generate-string response/response)))
+
+;; TODO: list-recipes not transformed to interceptors yet
+(def list-recipes [interceptors/db-interceptor
+                   http/transit-body
+                   list-recipes-response])
+
+
+;;; CREATE & UPDATE
+
+;; the common interceptor used by both create and update operations.
+;; They differ only in recipe-id handling and the actual response 
+(defn recipe-on-request
+  [{:keys [request] :as ctx}]
+  (let [account-id (get-in request [:headers "authorization"])
+        ;; parse path param (for update) or assign random id (for create)
+        recipe-id (or (some-> (get-in request [:path-params :recipe-id])
+                              parse-uuid)
+                      (random-uuid))
+        {:keys [name public prep-time img]} (:transit-params request)]
+    (assoc ctx
+           :tx-data [{:recipe/recipe-id recipe-id
+                      :recipe/display-name name ; shadowing core function
+                      :recipe/public? public
+                      :recipe/prep-time prep-time
+                      :recipe/image-url img
+                      ;; owner is actually a ref
+                      :recipe/owner [:account/account-id account-id]}]
+           :recipe-id (when-not (get-in request [:path-params :recipe-id])
+                        ;; add only for create operation
+                        recipe-id))))
+
+(defn recipe-on-response
+  [ctx]
+  (assoc ctx :response (if-let [id (:recipe-id ctx)]
+                         (response/created (str "/recipes/" id))
+                         {:status 200})))
+
+
+(def recipe-interceptor (around ::recipe recipe-on-request recipe-on-response))
+
+(def create-recipe
+  [recipe-interceptor
+   interceptors/transact-interceptor])
+
+(def update-recipe
+  [recipe-interceptor
+   interceptors/transact-interceptor])
+
+
+;;; GET
+(defn find-recipe-on-request
+  [ctx]
+  (prn "DEBUG:: find-recipe-on-request " find-recipe-on-request)
+  (let [recipe-id (parse-uuid (get-in ctx [:request :path-params :recipe-id]))]
+    (assoc ctx :q-data {:query '[:find (pull ?e pattern)
+                                 :in $ ?recipe-id pattern
+                                 :where [?e :recipe/recipe-id ?recipe-id]]
+                        ;; Notice that we do not add `db` as arg although it's required by datomic
+                        ;; - it is supplied by `query-interceptor`
+                        :args [recipe-id recipe-pattern]})))
+
+(defn find-recipe-on-response
+  [{:keys [q-result] :as ctx}]
+  (prn "DEBUG:: find-recipe-on-response " q-result)
+  (if (empty? q-result)
+    (response/not-found (str "recipe not found: " (-> ctx :q-data :args first)))
+    (response/response (query-result->recipe (first q-result)))))
+
+(def find-recipe-interceptor (around ::find-recipe find-recipe-on-request find-recipe-on-response))
+
+(def retrieve-recipe
+  [find-recipe-interceptor
+   interceptors/query-interceptor])
+
+
+;;; DELETE
+(defn retract-recipe-on-request
+  [ctx]
+  (let [recipe-id (parse-uuid (get-in ctx [:request :path-params :recipe-id]))]
+    (assoc ctx :tx-data [[:db/retractEntity [:recipe/recipe-id recipe-id]]])
+    recipe-id))
+
+(defn retract-recipe-on-response
+  [ctx]
+  (assoc ctx :response {:status 204}))
+
+(def retract-recipe-interceptor
+  #_(around retract-recipe-on-request retract-recipe-on-response)
+  ;; verbose form - this is what `around` expands to:
+  (interceptor/interceptor
+   {:name ::retract-recipe
+    :enter retract-recipe-on-request
+    :leave retract-recipe-on-response}))
+
+(def delete-recipe
+  [retract-recipe-interceptor
+   ;; notice that I can add this one as the second interceptor because I want it to be applied
+   ;; after I added :tx-data to the context in `retract-recipe-response`
+   interceptors/transact-interceptor])
+

--- a/src/main/cheffy/routes.clj
+++ b/src/main/cheffy/routes.clj
@@ -1,11 +1,12 @@
 (ns cheffy.routes
   (:require
    [cheffy.recipes :as recipes]
+   [cheffy.recipes-with-interceptors :as recipes-i]
    [io.pedestal.http.route :as route]
    [io.pedestal.http :as http]))
 
-;; See http://pedestal.io/reference/defining-routes
-(def table-routes
+;; The former routes using `recipes` ns
+#_(def table-routes
   (route/expand-routes
    ;; IMPORTANT: make sure that `:host` matches your hostname, most likely 'localhost'
    ;; - otherwise you will get NOT FOUND in the browser when you try something like
@@ -19,6 +20,20 @@
      ["/recipes/:recipe-id" :delete #'recipes/delete-recipe-response :route-name :delete-recipe]}))
 ;; inspect `table-routes` again and notice `:path-params`:
 ;;     :path-params [:recipe-id]
+
+;; updated routes relying more heavily on interceptors as defined in recipes-with-interceptors ns
+(def table-routes
+  (route/expand-routes
+   ;; IMPORTANT: make sure that `:host` matches your hostname, most likely 'localhost'
+   ;; - otherwise you will get NOT FOUND in the browser when you try something like
+   ;;      http://localhost:3001/recipes
+   #{{:app-name :cheffy ::http/scheme :http ::http/host "localhost"}
+     ;; now define the routes themselves
+     ["/recipes" :get recipes-i/list-recipes-response :route-name :list-recipes]
+     ["/recipes" :post recipes-i/create-recipe :route-name :create-recipe]
+     ["/recipes/:recipe-id" :get recipes-i/retrieve-recipe :route-name :get-recipes]
+     ["/recipes/:recipe-id" :put recipes-i/update-recipe :route-name :update-recipe]
+     ["/recipes/:recipe-id" :delete recipes-i/delete-recipe :route-name :delete-recipe]}))
 
 ;; just as an example, here we show the 'terse' syntax - less verbose than in `table-routes`
 (comment

--- a/src/resources/simplelogger.properties
+++ b/src/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+# SLF4j simple configuration files used by io.pedestal.log
+# See https://stackoverflow.com/questions/14544991/how-to-configure-slf4j-simple
+org.slf4j.simpleLogger.defaultLogLevel=info # don't use debug - it will kill emacs :( 
+# trace db query executions
+org.slf4j.simpleLogger.log.cheffy.interceptors=trace


### PR DESCRIPTION
DB oeprations are now performed in the interceptors ns.
There's still problem with at least GET recipe because it returns empty result.
But at least POST (create) works properly.

## Logging

I added logging because it's been a huge help in sorting out the problems with handlers and interceptors.