### PR TITLE
34: Migrate to Peer library and fix the retrieve-recipe test.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -16,10 +16,18 @@
         }
 
  :aliases {:dev {:extra-paths ["src/dev"]
-                 :extra-deps {com.datomic/dev-local {:mvn/version "1.0.243"}
+                 :extra-deps {;; com.datomic/dev-local {:mvn/version "1.0.243"}
+                              ;; use Datomic Starter license (1 year)
+                              com.datomic/datomic-pro {:mvn/version "1.0.6397"}
+                              ;; + datomic client library: api: https://docs.datomic.com/on-prem/client/integrating-client-lib.html
+                              com.datomic/client-pro {:mvn/version "1.0.75"}
                               com.stuartsierra/component.repl {:mvn/version "1.0.0"}}}
            :test {:extra-paths ["src/test"]
-                  :extra-deps {com.datomic/dev-local {:mvn/version "1.0.243"}
+                  :extra-deps {;; com.datomic/dev-local {:mvn/version "1.0.243"}
+                               ;; use Datomic Starter license (1 year)
+                               com.datomic/datomic-pro {:mvn/version "1.0.6397"}
+                               ;; + datomic client library: api: https://docs.datomic.com/on-prem/client/integrating-client-lib.html
+                               com.datomic/client-pro {:mvn/version "1.0.75"}
                                com.stuartsierra/component.repl {:mvn/version "1.0.0"}}}}
 
  }

--- a/src/config/development.edn
+++ b/src/config/development.edn
@@ -7,13 +7,15 @@
  ;; for peer server setup with client lib see https://docs.datomic.com/on-prem/client/client-getting-started.html
  :database {;; :server-type :dev-local
 
-            ;; only needed for peer server
-            :server-type :peer-server ; only for Peer server
-            :access-key "myaccesskey" ; only for Peer server
-            :secret "mysecret" ; only for Peer server
-            :endpoint "localhost:8998" ; only for Peer server
-            :validate-hostnames false ; only for Peer server
-            :db-uri "datomic:dev://localhost:4334/learn-pedestal-development" ; only for Peer library
+            ;; only needed for Peer server
+            :server-type :peer-server
+            :access-key "myaccesskey"
+            :secret "mysecret"
+            :endpoint "localhost:8998"
+            :validate-hostnames false
+
+            ;; only for Peer library
+            :db-uri "datomic:dev://localhost:4334/learn-pedestal-development"
 
             :storage-dir :mem ; only needed for dev-local
             :system "dev" ; in the video they used "api.learnpedestal.com"

--- a/src/config/development.edn
+++ b/src/config/development.edn
@@ -4,7 +4,17 @@
                :io.pedestal.http/port 3001
                :io.pedestal.http/join? false}
  ;; see https://docs.datomic.com/cloud/dev-local.html
- :database {:server-type :dev-local
+ ;; for peer server setup with client lib see https://docs.datomic.com/on-prem/client/client-getting-started.html
+ :database {;; :server-type :dev-local
+
+            ;; only needed for peer server
+            :server-type :peer-server ; only for Peer server
+            :access-key "myaccesskey" ; only for Peer server
+            :secret "mysecret" ; only for Peer server
+            :endpoint "localhost:8998" ; only for Peer server
+            :validate-hostnames false ; only for Peer server
+            :db-uri "datomic:dev://localhost:4334/learn-pedestal-development" ; only for Peer library
+
+            :storage-dir :mem ; only needed for dev-local
             :system "dev" ; in the video they used "api.learnpedestal.com"
-            :storage-dir :mem
-            :db-name "development"}}
+            :db-name "learn-pedestal-development"}}

--- a/src/dev/dev.clj
+++ b/src/dev/dev.clj
@@ -305,3 +305,27 @@
 ;; => []
 
   .)
+
+
+
+;;; random datomic debugging
+(comment
+  ;; list all entitities ids having specific attribute
+  (let [conn (-> cr/system :database :conn)
+        db (d/db conn)]
+    (d/q '[:find ?e
+           :where [?e :recipe/image-url]]
+         db))
+  ;; => [[74766790688882] [74766790688883] [74766790688884] [74766790688885]]
+
+  ;; find entity by internal id: https://stackoverflow.com/questions/42364172/how-can-i-use-datomics-pull-method-to-grab-an-entity-by-its-entity-id
+  (def my-db (d/db (-> cr/system :database :conn)))
+  (d/pull my-db '[*] 74766790688882)
+;; => {:db/id 74766790688882, :recipe/recipe-id #uuid "a3dde84c-4a33-45aa-b0f3-4bf9ac997680", :recipe/owner #:db{:id 74766790688872}, :recipe/display-name "Splitony's Pizza", :recipe/prep-time 45, :recipe/favorite-count 3, :recipe/image-url "https://res.cloudinary.com/schae/image/upload/f_auto,h_400,q_80/v1548183465/cheffy/recipe/pizza.jpg", :recipe/public? false}
+
+  ;; but for the recipe I created from within the test - the data is empty!
+  (d/pull my-db '[*] 13194139533326)
+;; => #:db{:id 13194139533326, :txInstant #inst "2022-08-01T04:42:12.635-00:00"}
+
+
+  .)

--- a/src/main/cheffy/components/database.clj
+++ b/src/main/cheffy/components/database.clj
@@ -1,43 +1,84 @@
 (ns cheffy.components.database
   "Uses datomic to provide persistent storage.
   For setup, see https://docs.datomic.com/cloud/dev-local.html"
-  (:require [com.stuartsierra.component :as component]
-            [datomic.client.api :as d]
-            ;; this is closed-source
-            [datomic.dev-local :as dl]
-            [clojure.java.io :as io]
-            [clojure.edn :as edn]))
+  (:require
+   [com.stuartsierra.component :as component]
+
+   ;; only for dev-local / client-library
+   #_[datomic.client.api :as d]
+   #_[datomic.dev-local :as dl] ; (closed source)
+   [datomic.api :as d]
+
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]))
 
 
 (defn ident-has-attr?
   "Checks whether there's a db entity with with given id and attribute."
   [db ident attr]
-  (contains? (d/pull db {:eid ident :selector '[*]})
-             attr))
+  (contains?
+   ;; only for dev-local / client library
+   #_(d/pull db {:eid ident :selector '[*]})
+   ;; only for peer library - entity id and patter are separate args
+   (d/pull db '[*] ident)
+   attr))
 
 (defn- load-data [resource-path]
   (-> (io/resource resource-path) slurp edn/read-string))
 
 (defn load-dataset [conn]
   (let [db (d/db conn)
-        tx #(d/transact conn {:tx-data %})]
+        ;; only for dev-local / datomic client library
+        #_#_tx #(d/transact conn {:tx-data %})
+        ;; only for Peer library - accepts tx-data directly and returns a future
+        tx #(->> % (d/transact conn) deref)
+        ]
     (when-not (ident-has-attr? db :account/account-id :db/ident)
       (tx (load-data "schema.edn"))
       (tx (load-data "seed.edn")))))
 
-
 (defn- start-db [db-config]
   (println "Starting database...")
-  (let [db-name (select-keys db-config [:db-name])
-        client (d/client (select-keys db-config [:server-type :storage-dir :system]))
-        _ (d/create-database client db-name)
-        conn (d/connect client db-name)]
+  (let [db-name-map (select-keys db-config [:db-name])
+
+        ;; client-config for dev-local
+        #_#_client-config (select-keys db-config [:server-type :storage-dir :system])
+
+        ;; client-config for peer server: https://docs.datomic.com/on-prem/client/client-getting-started.html#connect-to-a-database
+        client-config (select-keys db-config [:server-type :access-key :secret :endpoint :validate-hostnames])
+
+        ;; create the client and connect - only for dev-local and peer server
+        #_#_client (d/client client-config)
+
+        db-uri (:db-uri db-config)
+
+        ;; create-database only applies to Peer library (https://docs.datomic.com/on-prem/getting-started/connect-to-a-database.html#create-db)
+        ;; and dev-local;
+        ;; but not when using the Client library with Peer Server (https://docs.datomic.com/on-prem/client/client-getting-started.html#connect-to-a-database)
+        ;; only for dev-local: create the db using the client
+        #_#__ (d/create-database client db-name-map)
+        ;; only for Peer library: create database using db-uri
+        _ (d/create-database db-uri)
+
+        ;; use client to get the connection: only for dev-local and peer-server
+        #_#_conn (d/connect client db-name-map)
+        ;; use db-uri to connect (when in Peer mode: https://docs.datomic.com/on-prem/getting-started/connect-to-a-database.html)
+        conn (d/connect db-uri)
+        ]
     (load-dataset conn)
     conn))
 
 (defn- stop-db [db-config]
   (println "Stopping database...")
-  (dl/release-db (select-keys db-config [:system :db-name :meme])))
+  ;; only for dev-local
+  #_(dl/release-db (select-keys db-config [:system :db-name :meme]))
+  ;; only peer library: https://docs.datomic.com/on-prem/clojure/index.html#datomic.api/release
+  ;;   Note that Datomic connections do not adhere to an acquire/use/release 
+  ;;   pattern.  They are thread-safe, cached, and long lived.  Many 
+  ;;   processes (e.g. application servers) will never call release.
+  #_(d/release (:db-uri db-config)) ; no need to call this - see the comment
+
+  )
 
 (defrecord Database [config conn]
   component/Lifecycle

--- a/src/main/cheffy/recipes.clj
+++ b/src/main/cheffy/recipes.clj
@@ -1,6 +1,8 @@
 (ns cheffy.recipes
   (:require
-   [datomic.client.api :as d]
+   ;; only for dev-local / client-library
+   #_[datomic.client.api :as d]
+   [datomic.api :as d]
    [cheffy.interceptors :as interceptors]
    [cheshire.core :as json]
    [ring.util.response :as response]

--- a/src/main/cheffy/recipes_with_interceptors.clj
+++ b/src/main/cheffy/recipes_with_interceptors.clj
@@ -141,8 +141,8 @@
   [{:keys [q-result] :as ctx}]
   (prn "DEBUG:: find-recipe-on-response " q-result)
   (if (empty? q-result)
-    (response/not-found (str "recipe not found: " (-> ctx :q-data :args first)))
-    (response/response (query-result->recipe (first q-result)))))
+    (assoc ctx :response (response/not-found (str "recipe not found: " (-> ctx :q-data :args first))))
+    (assoc ctx :response (response/response (query-result->recipe (first q-result))))))
 
 (def find-recipe-interceptor (around ::find-recipe find-recipe-on-request find-recipe-on-response))
 

--- a/src/main/cheffy/recipes_with_interceptors.clj
+++ b/src/main/cheffy/recipes_with_interceptors.clj
@@ -8,7 +8,9 @@
   This really hampers debugging because functions' values are captured at the time the interceptors
   are defined and are thus hard to refresh (impossible with cider debugger?)"
   (:require
-   [datomic.client.api :as d]
+   ;; only for dev-local / client-library
+   #_[datomic.client.api :as d]
+   [datomic.api :as d]
    [cheffy.interceptors :as interceptors]
    [cheshire.core :as json]
    [ring.util.response :as response]

--- a/src/resources/simplelogger.properties
+++ b/src/resources/simplelogger.properties
@@ -3,3 +3,5 @@
 org.slf4j.simpleLogger.defaultLogLevel=info # don't use debug - it will kill emacs :( 
 # trace db query executions
 org.slf4j.simpleLogger.log.cheffy.interceptors=trace
+# datomic.process-monitor is quite noisy and can kill Emacs with all that output if it's running for many hours
+org.slf4j.simpleLogger.log.datomic.process-monitor=warn

--- a/src/test/cheffy/recipes_test.clj
+++ b/src/test/cheffy/recipes_test.clj
@@ -37,9 +37,6 @@
     (let [{:keys [body]} (ok-response 201 :post "/recipes"
                                       :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
                                                 "Content-Type" "application/transit+json"}
-                                      ;; TODO TODO TODO!
-                                      ;; TODO: check logs and notice that this doesn't work
-                                      ;; - :name, :public, :prep-time and :img are all nil!
                                       :body (transit-write {:name "name"
                                                             :public true
                                                             :prep-time 30
@@ -53,4 +50,6 @@
   (testing "retrieve recipe"
     (let [{:keys [body]} (ok-response 200 :get (str "/recipes/" @recipe-id-store)
                                       :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})]
-      (is (uuid? (:recipe-id body))))))
+      (is (uuid? (:recipe/recipe-id body))))))
+
+

--- a/src/test/cheffy/recipes_test.clj
+++ b/src/test/cheffy/recipes_test.clj
@@ -35,7 +35,8 @@
         (is (nil? (get body "drafts"))))))
   (testing "create recipe"
     (let [{:keys [body]} (ok-response 201 :post "/recipes"
-                                      :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"}
+                                      :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
+                                                "Content-Type" "application/transit+json"}
                                       ;; TODO TODO TODO!
                                       ;; TODO: check logs and notice that this doesn't work
                                       ;; - :name, :public, :prep-time and :img are all nil!


### PR DESCRIPTION
This (almost) finally fixes my problem with retrieve recipe test.
By doing the migration, I found that I was using `transact` incorrectly:
I passed tx-data as a top-level arg instead of putting it in a map
under the `:tx-data` key.

This approach is fine for Peer library but the APIs are different.
Now it's indeed transacting new data.

I also had to fix returning the response for the route handler - I forgot
to actually return an updated context with `:response` key set;
instead, I simply returned ring response map.