### PR TITLE
37-38: 'create step' API and test

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,11 @@
  ;; https://github.com/pedestal/pedestal#getting-the-latest-release
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
 
+        ;; use Datomic Starter license (1 year)
+        com.datomic/datomic-pro {:mvn/version "1.0.6397"}
+        ;; + datomic client library: api: https://docs.datomic.com/on-prem/client/integrating-client-lib.html
+        com.datomic/client-pro {:mvn/version "1.0.75"}
+
         io.pedestal/pedestal.service {:mvn/version "0.5.10"}
         io.pedestal/pedestal.route {:mvn/version "0.5.10"}
         io.pedestal/pedestal.jetty {:mvn/version "0.5.10"}
@@ -17,19 +22,11 @@
         org.slf4j/slf4j-simple {:mvn/version "1.7.36"}
         }
 
- :aliases {:dev {:extra-paths ["src/dev"]
+ :aliases {:dev {:extra-paths ["src/dev" "src/test"]
                  :extra-deps {;; com.datomic/dev-local {:mvn/version "1.0.243"}
-                              ;; use Datomic Starter license (1 year)
-                              com.datomic/datomic-pro {:mvn/version "1.0.6397"}
-                              ;; + datomic client library: api: https://docs.datomic.com/on-prem/client/integrating-client-lib.html
-                              com.datomic/client-pro {:mvn/version "1.0.75"}
                               com.stuartsierra/component.repl {:mvn/version "1.0.0"}}}
            :test {:extra-paths ["src/test"]
                   :extra-deps {;; com.datomic/dev-local {:mvn/version "1.0.243"}
-                               ;; use Datomic Starter license (1 year)
-                               com.datomic/datomic-pro {:mvn/version "1.0.6397"}
-                               ;; + datomic client library: api: https://docs.datomic.com/on-prem/client/integrating-client-lib.html
-                               com.datomic/client-pro {:mvn/version "1.0.75"}
                                com.stuartsierra/component.repl {:mvn/version "1.0.0"}}}}
 
  }

--- a/src/main/cheffy/components/api_server.clj
+++ b/src/main/cheffy/components/api_server.clj
@@ -40,7 +40,7 @@
   (assoc service-map ::http/routes
          (if (dev? service-map)
            ;; notice they used #(routes/routes) instead
-           routes/routes
+           #(routes/routes)
            (routes/routes))))
 
 (defn- start-server [service-map database]

--- a/src/main/cheffy/interceptors.clj
+++ b/src/main/cheffy/interceptors.clj
@@ -31,14 +31,15 @@
   [{:keys [tx-data] :as ctx}]
   (log/debug :transact tx-data)
   #_(def my-ctx ctx)
-  (when-let [result (when tx-data
+  (if-let [result (when tx-data
                              ;; only for dev-local / Client library
-                             #_(d/transact (connection ctx {:tx-data tx-data}))
+                    #_(d/transact (connection ctx {:tx-data tx-data}))
                              ;; only for Peer library - accepts tx-data directly and returns a future
-                             @(d/transact (connection ctx) tx-data)
-                             )]
-    (log/trace :tx-result result)
-    (assoc ctx :tx-result result)))
+                    @(d/transact (connection ctx) tx-data))]
+    (do (log/trace :tx-result result)
+        (assoc ctx :tx-result result))
+    (do (log/warn :tx-result "no result!")
+        ctx)))
 
 (defn- query!
   [{:keys [q-data] :as ctx}]

--- a/src/main/cheffy/routes.clj
+++ b/src/main/cheffy/routes.clj
@@ -2,6 +2,7 @@
   (:require
    [cheffy.recipes :as recipes]
    [cheffy.recipes-with-interceptors :as recipes-i]
+   [cheffy.steps :as steps]
    [io.pedestal.http.route :as route]
    [io.pedestal.http :as http]))
 
@@ -33,7 +34,10 @@
      ["/recipes" :post recipes-i/create-recipe :route-name :create-recipe]
      ["/recipes/:recipe-id" :get recipes-i/retrieve-recipe :route-name :get-recipes]
      ["/recipes/:recipe-id" :put recipes-i/update-recipe :route-name :update-recipe]
-     ["/recipes/:recipe-id" :delete recipes-i/delete-recipe :route-name :delete-recipe]}))
+     ["/recipes/:recipe-id" :delete recipes-i/delete-recipe :route-name :delete-recipe]
+
+     ;; Note: in the previous courses, steps routes were deeply nested under the /recipes/:recipe-id routes
+     ["/steps" :post steps/create-step :route-name :create-step]}))
 
 ;; just as an example, here we show the 'terse' syntax - less verbose than in `table-routes`
 (comment

--- a/src/main/cheffy/steps.clj
+++ b/src/main/cheffy/steps.clj
@@ -1,16 +1,25 @@
 (ns cheffy.steps
+  "Route handlers / interceptors for recipe steps."
   (:require
    [cheffy.interceptors :as interceptors]
    [io.pedestal.interceptor.helpers :refer [around]]
    [ring.util.response :as response]))
 
 (defn step-on-request [{:keys [request] :as ctx}]
-  ctx
-  )
+  (let [{:keys [recipe-id description sort-order]} (:transit-params request)
+        ;; TODO: get value from request for UPDATE operation
+        step-id (random-uuid)]
+    (assoc ctx :tx-data [{:recipe/recipe-id recipe-id
+                          :recipe/steps [{:step/step-id step-id
+                                          :step/description description
+                                          :step/sort-order sort-order}]}])))
 
-(defn step-on-response [{:keys [request] :as ctx}]
-  (prn "step-on-response")
-  (assoc ctx :response (response/response {:msg "ok"})))
+(defn step-on-response [{:keys [tx-data] :as ctx}]
+  (let [{:recipe/keys [recipe-id steps]} (first tx-data)
+        step-id (-> steps first :step/step-id)]
+    ;; TODO: shouldn't we return a link to '/steps/<step-id>' instead?
+    (assoc ctx :response (response/created (str "/recipes/" recipe-id)
+                                           {:step-id step-id}))))
 
 (def step-interceptor (around ::step step-on-request step-on-response))
 

--- a/src/main/cheffy/steps.clj
+++ b/src/main/cheffy/steps.clj
@@ -1,0 +1,19 @@
+(ns cheffy.steps
+  (:require
+   [cheffy.interceptors :as interceptors]
+   [io.pedestal.interceptor.helpers :refer [around]]
+   [ring.util.response :as response]))
+
+(defn step-on-request [{:keys [request] :as ctx}]
+  ctx
+  )
+
+(defn step-on-response [{:keys [request] :as ctx}]
+  (prn "step-on-response")
+  (assoc ctx :response (response/response {:msg "ok"})))
+
+(def step-interceptor (around ::step step-on-request step-on-response))
+
+(def create-step
+  [step-interceptor
+   interceptors/transact-interceptor])

--- a/src/resources/seed.edn
+++ b/src/resources/seed.edn
@@ -19,7 +19,7 @@
 
  ; steps
  {:db/id "step_1"
-  :step/step-id #uuid"867ed4bf-4628-48f4-944d-e6b7786bfa92"
+  :step/step-id #uuid "867ed4bf-4628-48f4-944d-e6b7786bfa92"
   :step/description "First step"
   :step/sort-order 1}
 

--- a/src/test/cheffy/recipes_test.clj
+++ b/src/test/cheffy/recipes_test.clj
@@ -1,26 +1,8 @@
-(ns test.cheffy.recipes-test
-  (:require [cheffy.util.transit :refer [transit-read transit-write]]
-            [clojure.test :refer [deftest is testing]]
-            [com.stuartsierra.component.repl :as cr]
-            [io.pedestal.test :as pt]
-            [io.pedestal.http :as http]))
-
-
-(defn- assert-response
-  [expected-status method path & options]
-  (let [response (apply pt/response-for
-                        (-> cr/system :api-server :service ::http/service-fn)
-                        method
-                        path
-                        options)]
-    (is (= expected-status (:status response)))
-    response))
-
-(defn- assert-response-body
-  ;; for destructuring, see https://clojure.org/guides/destructuring#_keyword_arguments
-  [expected-status method path & options]
-  (let [response (apply assert-response expected-status method path options)]
-    (update response :body transit-read)))
+(ns cheffy.recipes-test
+  (:require
+   [cheffy.util.transit :refer [transit-write]]
+   [clojure.test :refer [deftest is testing]]
+   [test-utils :as tu]))
 
 ;; a bit nasty but does its work - this is set by 'create recipe' test
 ;; and used by the subsequent tests
@@ -28,37 +10,38 @@
 ;; manually without preparing the recipe first
 (def recipe-id-store (atom nil))
 
+(defn create-recipe
+  "Creates a new recipe and returns it's body."
+  []
+  (let [recipe-id (:recipe-id (tu/create-entity "/recipes" {:name "name"
+                                                            :public true
+                                                            :prep-time 30
+                                                            :img "https://github.com/clojure.png"}))]
+    (is (uuid? recipe-id))
+    recipe-id))
+
 (deftest recipes-test
   (testing "list recipes"
     (testing "with auth -- public and drafts"
-      (let [{:keys [body]} (assert-response-body 200
+      (let [{:keys [body]} (tu/assert-response-body 200
                                                  :get "/recipes"
                                                  :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})]
         (is (vector? (get body "public")))
         (is (vector? (get body "drafts")))))
     (testing "without auth -- only public "
-      (let [{:keys [body]} (assert-response-body 200 :get "/recipes")]
+      (let [{:keys [body]} (tu/assert-response-body 200 :get "/recipes")]
         (is (vector? (get body "public")))
         (is (nil? (get body "drafts"))))))
   (testing "create recipe"
-    (let [{:keys [body]} (assert-response-body 201
-                                               :post "/recipes"
-                                               :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
-                                                         "Content-Type" "application/transit+json"}
-                                               :body (transit-write {:name "name"
-                                                                     :public true
-                                                                     :prep-time 30
-                                                                     :img "https://github.com/clojure.png"}))
-          recipe-id (:recipe-id body)]
-      (is (uuid? recipe-id))
+    (let [recipe-id (create-recipe)]
       (reset! recipe-id-store recipe-id)))
   (testing "retrieve recipe"
-    (let [{:keys [body]} (assert-response-body 200
+    (let [{:keys [body]} (tu/assert-response-body 200
                                                :get (str "/recipes/" @recipe-id-store)
                                                :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})]
       (is (uuid? (:recipe/recipe-id body)))))
   (testing "update recipe"
-    (assert-response 200
+    (tu/assert-response 200
                      :put (str "/recipes/" @recipe-id-store)
                      :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
                                "Content-Type" "application/transit+json"}
@@ -68,21 +51,22 @@
                                            :img "https://github.com/clojure.png"}))
     ;; get again and check that the name was updated
     (is (= "updated name"
-           (-> (assert-response-body
+           (-> (tu/assert-response-body
                 200 :get (str "/recipes/" @recipe-id-store)
                 :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})
                :body
                :recipe/display-name))))
   (testing "delete recipe"
-    (assert-response 204
+    (tu/assert-response 204
                      :delete (str "/recipes/" @recipe-id-store)
                      :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
                                "Content-Type" "application/transit+json"})
 
     ;; get again and check that the name was updated
-    (assert-response 404
+    (tu/assert-response 404
                      :get (str "/recipes/" @recipe-id-store)
                      :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})))
+
 
 
 

--- a/src/test/cheffy/steps_test.clj
+++ b/src/test/cheffy/steps_test.clj
@@ -22,16 +22,11 @@
   (testing "create step"
     ;; first create a recipe so we can reference it
     (let [recipe-id (recipes-test/create-recipe)
-          {:keys [body]}
-          (tu/assert-response-body 201
-                                   :post "/steps"
-                                   :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
-                                             "Content-Type" "application/transit+json"}
-                                   :body (transit-write {:recipe-id recipe-id
-                                                         :description "My first recipe"
-                                                         :sort-order 1 ; TODO: not sure what this means
-                                                         }))
-          step-id (:step-id body)]
+          {:keys [step-id]} (tu/create-entity "/steps"
+                                              {:recipe-id recipe-id
+                                               :description "My first recipe"
+                                               :sort-order 1 ; TODO: not sure what this means
+                                               })]
       (is (uuid? step-id))
       (reset! step-id-store step-id)))
   #_(testing "retrieve recipe"

--- a/src/test/cheffy/steps_test.clj
+++ b/src/test/cheffy/steps_test.clj
@@ -1,0 +1,76 @@
+(ns cheffy.steps-test
+  (:require
+   [cheffy.recipes-test :as recipes-test]
+   [cheffy.util.transit :refer [transit-write]]
+   [clojure.test :refer [deftest is testing]]
+   [test-utils :as tu]))
+
+
+;; a bit nasty but does its work - this is set by 'create recipe' test
+;; and used by the subsequent tests
+;; It also has an advantage that you can run a single test such as 'retrieve recipe'
+;; manually without preparing the recipe first
+(def step-id-store (atom nil))
+
+(deftest recipes-test
+  #_(testing "list recipes"
+      (testing "with auth -- public and drafts"
+        (let [{:keys [body]} (tu/assert-response-body 200
+                                                      :get "/recipes"
+                                                      :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})]
+          (is (vector? (get body "public")))
+          (is (vector? (get body "drafts")))))
+      (testing "without auth -- only public "
+        (let [{:keys [body]} (tu/assert-response-body 200 :get "/recipes")]
+          (is (vector? (get body "public")))
+          (is (nil? (get body "drafts"))))))
+  (testing "create step"
+    ;; first create a recipe so we can reference it
+    (let [recipe-id (recipes-test/create-recipe)
+          {:keys [body]}
+          (tu/assert-response-body 201
+                                   :post "/steps"
+                                   :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
+                                             "Content-Type" "application/transit+json"}
+                                   :body (transit-write {:recipe-id recipe-id
+                                                         :description "My first recipe"
+                                                         :sort-order 1 ; TODO: not sure what this means
+                                                         }))
+          step-id (:step-id body)]
+      (is (uuid? step-id))
+      (reset! step-id-store step-id)))
+  #_(testing "retrieve recipe"
+      (let [{:keys [body]} (tu/assert-response-body 200
+                                                    :get (str "/recipes/" @step-id-store)
+                                                    :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})]
+        (is (uuid? (:recipe/recipe-id body)))))
+  #_(testing "update recipe"
+      (tu/assert-response 200
+                          :put (str "/recipes/" @step-id-store)
+                          :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
+                                    "Content-Type" "application/transit+json"}
+                          :body (transit-write {:name "updated name"
+                                                :public true
+                                                :prep-time 30
+                                                :img "https://github.com/clojure.png"}))
+    ;; get again and check that the name was updated
+      (is (= "updated name"
+             (-> (tu/assert-response-body
+                  200 :get (str "/recipes/" @step-id-store)
+                  :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})
+                 :body
+                 :recipe/display-name))))
+  #_(testing "delete recipe"
+      (tu/assert-response 204
+                          :delete (str "/recipes/" @step-id-store)
+                          :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
+                                    "Content-Type" "application/transit+json"})
+
+    ;; get again and check that the name was updated
+      (tu/assert-response 404
+                          :get (str "/recipes/" @step-id-store)
+                          :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"})))
+
+
+
+

--- a/src/test/cheffy/steps_test.clj
+++ b/src/test/cheffy/steps_test.clj
@@ -5,14 +5,9 @@
    [clojure.test :refer [deftest is testing]]
    [test-utils :as tu]))
 
-
-;; a bit nasty but does its work - this is set by 'create recipe' test
-;; and used by the subsequent tests
-;; It also has an advantage that you can run a single test such as 'retrieve recipe'
-;; manually without preparing the recipe first
 (def step-id-store (atom nil))
 
-(deftest recipes-test
+(deftest steps-test
   #_(testing "list recipes"
       (testing "with auth -- public and drafts"
         (let [{:keys [body]} (tu/assert-response-body 200

--- a/src/test/test_utils.clj
+++ b/src/test/test_utils.clj
@@ -1,0 +1,36 @@
+(ns test-utils
+  (:require
+   [cheffy.util.transit :refer [transit-read transit-write]]
+   [clojure.test :refer [is]]
+   [com.stuartsierra.component.repl :as cr]
+   [io.pedestal.test :as pt]
+   [io.pedestal.http :as http]))
+
+(defn assert-response
+  [expected-status method path & options]
+  (let [response (apply pt/response-for
+                        (-> cr/system :api-server :service ::http/service-fn)
+                        method
+                        path
+                        options)]
+    (is (= expected-status (:status response)))
+    response))
+
+(defn assert-response-body
+  ;; for destructuring, see https://clojure.org/guides/destructuring#_keyword_arguments
+  [expected-status method path & options]
+  (let [response (apply assert-response expected-status method path options)]
+    (update response :body transit-read)))
+
+
+(defn create-entity
+  "Creates a new entity at given path and returns response body.
+  Automatically adds Authorization header using one of the seed accounts.
+  Assumes response status 201."
+  [path entity-data]
+  (get (assert-response-body 201
+                             :post path
+                             :headers {"Authorization" "auth|5fbf7db6271d5e0076903601"
+                                       "Content-Type" "application/transit+json"}
+                             :body (transit-write entity-data))
+       :body))


### PR DESCRIPTION
This also introduces a bunch of things and refactorings:

- I fixed transcact interceptor to always return a context, even if results are nil
  - this is especially important when the implementation of route handler is incorrect
- I extracted common test-utils ns to avoid duplication between recipes-test and steps-test
- I added "src/test" to the :dev alias paths - needed when using new test-utils
- api-server now references `#(routes/routes)` instead of simple `routes/routes`
  - I have suspicion that the latter wasn't as reloadable as I thought.
- 'create step' route handler implemented similarly to creat-recipe in recipe-with-interceptors
- new steps-test ns created with basic 'create step' test.
