### PR TITLE
Refactor: extract common interceptors into `crud` ns.

### DIFF
--- a/src/main/cheffy/crud.clj
+++ b/src/main/cheffy/crud.clj
@@ -1,0 +1,81 @@
+(ns cheffy.crud
+  "Generic CRUD handlers reusable for different entities like recipes, steps, ingredients, etc.
+
+  There are 3 main public functions representing the 4 operations:
+  - `upsert` - for Create (POST) and Update (PUT)
+  - `retrieve` - for GET
+  - `delete` - for DELETE
+  All of them take at least `id-key` that is a namespaced keyword representing the Datomic entity ID,
+  e.g. `:recipe/recipe-id`, `:ingredient/ingredient-id`, etc.
+  The sipmle (non-namespaced) version of `id-key` is used to lookup the ID in request's `:path-params`."
+  (:require
+   [cheffy.interceptors :as interceptors]
+   [io.pedestal.interceptor.helpers :refer [around]]
+   [ring.util.response :as response]))
+
+(defn simple-id [id-key]
+  (keyword (name id-key)))
+
+;;; CREATE + UPDATE
+(defn- entity-on-request [id-key params->entity-fn]
+  (fn [{:keys [request] :as ctx}]
+    (let [entity-id (or (some-> (get-in request [:path-params (simple-id id-key)]) parse-uuid)
+                        (random-uuid))
+          entity (params->entity-fn entity-id (:transit-params request))]
+      (assoc ctx
+             :tx-data [entity]
+             :entity-id entity-id
+             :update? (boolean (get-in request [:path-params (simple-id id-key)]))))))
+
+(defn- entity-on-response [id-key]
+  (fn [{:keys [entity-id] :as ctx}]
+    (assoc ctx :response
+           (if (:update? ctx)
+             {:status 204}
+             (response/created (str "/" (namespace id-key) "s/" ; to get e.g. "/recipes/"
+                                    entity-id)
+                               {(simple-id id-key) entity-id})))))
+
+(defn upsert
+  "Takes id-key and a function to convert body parameters (:transit-params)
+  to a Datomic entity data suitable for passing as `:tx-data`
+  (the entity will be wrapped in a vector and passed as `:tx-data` without further modifications)."
+  [id-key params->entity-fn]
+  [(around (entity-on-request id-key params->entity-fn) (entity-on-response id-key))
+   interceptors/transact-interceptor])
+
+;;; GET
+(defn- find-on-request [id-key]
+  (fn [ctx]
+    (let [entity-id (parse-uuid (get-in ctx [:request :path-params (simple-id id-key)]))]
+      (assoc ctx :q-data {:query '[:find (pull ?e [*])
+                                   :in $ ?id-key ?entity-id
+                                   :where [?e ?id-key ?entity-id]]
+                          ;; Notice that we do not add `db` as arg although it's required by datomic
+                          ;; - it is supplied by `query-interceptor`
+                          :args [id-key entity-id]}))))
+
+(defn- find-on-response [{:keys [q-result] :as ctx}]
+  (if (empty? q-result)
+    (assoc ctx :response (response/not-found (str "Entity not found: " (-> ctx :q-data :args first))))
+    (assoc ctx :response (response/response (ffirst q-result)))))
+
+(defn retrieve [id-key]
+  [(around (find-on-request id-key) find-on-response)
+   interceptors/query-interceptor])
+
+;;; DELETE
+(defn- retract-on-request [id-key]
+  (fn [{:keys [request] :as ctx}]
+    (let [entity-id (parse-uuid (get-in request [:path-params (simple-id id-key)]))]
+      (assoc ctx :tx-data [[:db/retractEntity [id-key entity-id]]]))))
+
+(defn- retract-on-response [ctx]
+  (assoc ctx :response (response/status 204)))
+
+(defn delete [id-key]
+  [(around (retract-on-request id-key) retract-on-response)
+   interceptors/transact-interceptor])
+
+;;; TODO: add `crud` macro that will generate all the route handlers
+;;; instead of manually defining all 4 of them as defs?

--- a/src/main/cheffy/ingredients.clj
+++ b/src/main/cheffy/ingredients.clj
@@ -4,7 +4,6 @@
   See also `seed.edn` file to explore ingredients data."
   (:require [cheffy.crud :as crud]))
 
-
 (def id-key :ingredient/ingredient-id)
 
 (defn- params->entity

--- a/src/main/cheffy/ingredients.clj
+++ b/src/main/cheffy/ingredients.clj
@@ -2,74 +2,23 @@
   "Route handlers / interceptors for ingredients - see Lesson 42:
   https://www.jacekschae.com/view/courses/learn-pedestal-pro/1409479-ingredients-and-ingredients/4435320-42-ingredient.
   See also `seed.edn` file to explore ingredients data."
-  (:require
-   [cheffy.interceptors :as interceptors]
-   [io.pedestal.interceptor.helpers :refer [around]]
-   [ring.util.response :as response]))
+  (:require [cheffy.crud :as crud]))
 
-(defn ingredient-on-request [{:keys [request] :as ctx}]
-  (let [{:keys [recipe-id name amount measure sort-order]} (:transit-params request)
-        ingredient-id (or (some-> (get-in request [:path-params :ingredient-id]) parse-uuid)
-                          (random-uuid))]
-    (assoc ctx
-           :tx-data [{:recipe/recipe-id recipe-id
-                      :recipe/ingredients [{:ingredient/ingredient-id ingredient-id
-                                            :ingredient/display-name name
-                                            :ingredient/amount amount
-                                            :ingredient/measure measure
-                                            :ingredient/sort-order sort-order}]}]
-           :update? (when (get-in request [:path-params :ingredient-id])
-                      ingredient-id))))
 
-(defn ingredient-on-response [{:keys [tx-data] :as ctx}]
-  (let [{:recipe/keys [ingredients]} (first tx-data)
-        ingredient-id (-> ingredients first :ingredient/ingredient-id)]
-    (assoc ctx :response
-           (if (:update? ctx)
-             {:status 204}
-             (response/created (str "/ingredients/" ingredient-id)
-                               {:ingredient-id ingredient-id})))))
+(def id-key :ingredient/ingredient-id)
 
-(def ingredient-interceptor (around ::ingredient ingredient-on-request ingredient-on-response))
+(defn- params->entity
+  [entity-id {:keys [recipe-id name amount measure sort-order] :as _params}]
+  {:recipe/recipe-id recipe-id
+   :recipe/ingredients [{:ingredient/ingredient-id entity-id
+                         :ingredient/display-name name
+                         :ingredient/amount amount
+                         :ingredient/measure measure
+                         :ingredient/sort-order sort-order}]})
 
-(def upsert-ingredient
-  [ingredient-interceptor
-   interceptors/transact-interceptor])
+(def upsert-ingredient (crud/upsert id-key params->entity))
 
-;;; GET ingredient - Note: this isn't covered in the course
-;;; but it was convenient  (e.g. in the update tests).
-(defn find-ingredient-on-request
-  [ctx]
-  (let [ingredient-id (parse-uuid (get-in ctx [:request :path-params :ingredient-id]))]
-    (assoc ctx :q-data {:query '[:find (pull ?e [*])
-                                 :in $ ?ingredient-id
-                                 :where [?e :ingredient/ingredient-id ?ingredient-id]]
-                        ;; Notice that we do not add `db` as arg although it's required by datomic
-                        ;; - it is supplied by `query-interceptor`
-                        :args [ingredient-id]})))
+(def retrieve-ingredient (crud/retrieve id-key))
 
-(defn find-ingredient-on-response
-  [{:keys [q-result] :as ctx}]
-  (if (empty? q-result)
-    (assoc ctx :response (response/not-found (str "ingredient not found: " (-> ctx :q-data :args first))))
-    (assoc ctx :response (response/response (ffirst q-result)))))
-
-(def find-ingredient-interceptor (around ::find-ingredient find-ingredient-on-request find-ingredient-on-response))
-
-(def retrieve-ingredient
-  [find-ingredient-interceptor
-   interceptors/query-interceptor])
-
-(defn retract-ingredient-on-request [{:keys [request] :as ctx}]
-  (let [ingredient-id (parse-uuid (get-in request [:path-params :ingredient-id]))]
-    (assoc ctx :tx-data [[:db/retractEntity [:ingredient/ingredient-id ingredient-id]]])))
-
-(defn retract-ingredient-on-response [ctx]
-  (assoc ctx :response (response/status 204)))
-
-(def retract-ingredient-interceptor (around ::retract-ingredient retract-ingredient-on-request retract-ingredient-on-response))
-
-(def delete-ingredient
-  [retract-ingredient-interceptor
-   interceptors/transact-interceptor])
+(def delete-ingredient (crud/delete id-key))
 

--- a/src/main/cheffy/ingredients.clj
+++ b/src/main/cheffy/ingredients.clj
@@ -7,7 +7,7 @@
 (def id-key :ingredient/ingredient-id)
 
 (defn- params->entity
-  [entity-id {:keys [recipe-id name amount measure sort-order] :as _params}]
+  [_account-id entity-id {:keys [recipe-id name amount measure sort-order] :as _params}]
   {:recipe/recipe-id recipe-id
    :recipe/ingredients [{:ingredient/ingredient-id entity-id
                          :ingredient/display-name name

--- a/src/main/cheffy/recipes_obsolete.clj
+++ b/src/main/cheffy/recipes_obsolete.clj
@@ -1,4 +1,4 @@
-(ns cheffy.recipes
+(ns cheffy.recipes-obsolete
   (:require
    ;; only for dev-local / client-library
    #_[datomic.client.api :as d]

--- a/src/main/cheffy/routes.clj
+++ b/src/main/cheffy/routes.clj
@@ -1,6 +1,6 @@
 (ns cheffy.routes
   (:require
-   [cheffy.recipes :as recipes]
+   [cheffy.recipes-obsolete :as recipes-o]
    [cheffy.recipes-with-interceptors :as recipes-i]
    [cheffy.steps :as steps]
    [cheffy.ingredients :as ingredients]
@@ -15,11 +15,11 @@
    ;;      http://localhost:3001/recipes
    #{{:app-name :cheffy ::http/scheme :http ::http/host "localhost"}
      ;; now define the routes themselves
-     ["/recipes" :get #'recipes/list-recipes-response :route-name :list-recipes]
-     ["/recipes" :post #'recipes/create-recipe-response :route-name :create-recipe]
-     ["/recipes/:recipe-id" :get #'recipes/retrieve-recipe-response :route-name :get-recipes]
-     ["/recipes/:recipe-id" :put #'recipes/update-recipe-response :route-name :update-recipe]
-     ["/recipes/:recipe-id" :delete #'recipes/delete-recipe-response :route-name :delete-recipe]}))
+     ["/recipes" :get #'recipes-o/list-recipes-response :route-name :list-recipes]
+     ["/recipes" :post #'recipes-o/create-recipe-response :route-name :create-recipe]
+     ["/recipes/:recipe-id" :get #'recipes-o/retrieve-recipe-response :route-name :get-recipes]
+     ["/recipes/:recipe-id" :put #'recipes-o/update-recipe-response :route-name :update-recipe]
+     ["/recipes/:recipe-id" :delete #'recipes-o/delete-recipe-response :route-name :delete-recipe]}))
 ;; inspect `table-routes` again and notice `:path-params`:
 ;;     :path-params [:recipe-id]
 

--- a/src/main/cheffy/steps.clj
+++ b/src/main/cheffy/steps.clj
@@ -5,7 +5,7 @@
 (def id-key :step/step-id)
 
 (defn- params->entity
-  [entity-id {:keys [recipe-id description sort-order] :as _params}]
+  [_account-id entity-id {:keys [recipe-id description sort-order] :as _params}]
   {:recipe/recipe-id recipe-id
    :recipe/steps [{:step/step-id entity-id
                    :step/description description

--- a/src/main/cheffy/steps.clj
+++ b/src/main/cheffy/steps.clj
@@ -1,71 +1,20 @@
 (ns cheffy.steps
   "Route handlers / interceptors for recipe steps."
-  (:require
-   [cheffy.interceptors :as interceptors]
-   [io.pedestal.interceptor.helpers :refer [around]]
-   [ring.util.response :as response]))
+  (:require [cheffy.crud :as crud]))
 
-(defn step-on-request [{:keys [request] :as ctx}]
-  (let [{:keys [recipe-id description sort-order]} (:transit-params request)
-        step-id (or (some-> (get-in request [:path-params :step-id]) parse-uuid)
-                    (random-uuid))]
-    (assoc ctx
-           :tx-data [{:recipe/recipe-id recipe-id
-                      :recipe/steps [{:step/step-id step-id
-                                      :step/description description
-                                      :step/sort-order sort-order}]}]
-           :update? (when (get-in request [:path-params :step-id])
-                      step-id))))
+(def id-key :step/step-id)
 
-(defn step-on-response [{:keys [tx-data] :as ctx}]
-  (let [{:recipe/keys [steps]} (first tx-data)
-        step-id (-> steps first :step/step-id)]
-    (assoc ctx :response
-           (if (:update? ctx)
-             {:status 204}
-             (response/created (str "/steps/" step-id)
-                               {:step-id step-id})))))
+(defn- params->entity
+  [entity-id {:keys [recipe-id description sort-order] :as _params}]
+  {:recipe/recipe-id recipe-id
+   :recipe/steps [{:step/step-id entity-id
+                   :step/description description
+                   :step/sort-order sort-order}]})
 
-(def step-interceptor (around ::step step-on-request step-on-response))
+(def upsert-step (crud/upsert id-key params->entity))
 
-(def upsert-step
-  [step-interceptor
-   interceptors/transact-interceptor])
+(def retrieve-step (crud/retrieve id-key))
 
-;;; GET step - Note: this isn't covered in the course
-;;; but it was convenient  (e.g. in the update tests).
-(defn find-step-on-request
-  [ctx]
-  (let [step-id (parse-uuid (get-in ctx [:request :path-params :step-id]))]
-    (assoc ctx :q-data {:query '[:find (pull ?e [*])
-                                 :in $ ?step-id
-                                 :where [?e :step/step-id ?step-id]]
-                        ;; Notice that we do not add `db` as arg although it's required by datomic
-                        ;; - it is supplied by `query-interceptor`
-                        :args [step-id]})))
+(def delete-step (crud/delete id-key))
 
-(defn find-step-on-response
-  [{:keys [q-result] :as ctx}]
-  (if (empty? q-result)
-    (assoc ctx :response (response/not-found (str "step not found: " (-> ctx :q-data :args first))))
-    (assoc ctx :response (response/response (ffirst q-result)))))
-
-(def find-step-interceptor (around ::find-step find-step-on-request find-step-on-response))
-
-(def retrieve-step
-  [find-step-interceptor
-   interceptors/query-interceptor])
-
-(defn retract-step-on-request [{:keys [request] :as ctx}]
-  (let [step-id (parse-uuid (get-in request [:path-params :step-id]))]
-    (assoc ctx :tx-data [[:db/retractEntity [:step/step-id step-id]]])))
-
-(defn retract-step-on-response [ctx]
-  (assoc ctx :response (response/status 204)))
-
-(def retract-step-interceptor (around ::retract-step retract-step-on-request retract-step-on-response))
-
-(def delete-step
-  [retract-step-interceptor
-   interceptors/transact-interceptor])
 

--- a/src/test/cheffy/recipes_test.clj
+++ b/src/test/cheffy/recipes_test.clj
@@ -1,6 +1,5 @@
 (ns cheffy.recipes-test
   (:require
-   [cheffy.util.transit :refer [transit-write]]
    [clojure.test :refer [deftest is testing]]
    [test-utils :as tu]))
 


### PR DESCRIPTION
By extracting the common logic we unified it
and hugely simplified recipes, steps, and ingredients implementations.

They are all now almost trivial.
Recipes have one extra operation, that is list-recipes, so they are somewhat more complex than steps or ingredients.

For example, here's the complete implementation of steps.clj

```
(ns cheffy.steps
  "Route handlers / interceptors for recipe steps."
  (:require [cheffy.crud :as crud]))

(def id-key :step/step-id)

(defn- params->entity
  [_account-id entity-id {:keys [recipe-id description sort-order] :as _params}]
  {:recipe/recipe-id recipe-id
   :recipe/steps [{:step/step-id entity-id
                   :step/description description
                   :step/sort-order sort-order}]})

(def upsert-step (crud/upsert id-key params->entity))

(def retrieve-step (crud/retrieve id-key))

(def delete-step (crud/delete id-key))
```