### PR TITLE
Refactor list-recipes to use a single query and unified crud handler.

### DIFF
--- a/src/main/cheffy/crud.clj
+++ b/src/main/cheffy/crud.clj
@@ -18,6 +18,21 @@
 (defn simple-id [id-key]
   (keyword (name id-key)))
 
+;;; LIST (GET returning multiple entities)
+(defn- list-on-request [query-fn]
+  (fn [{:keys [request] :as ctx}]
+    (assoc ctx :q-data (query-fn request))))
+
+(defn- list-on-response [result-fn]
+  (fn [{:keys [q-result] :as ctx}]
+    (assoc ctx :response (response/response (result-fn q-result)))))
+
+
+(defn list [query-fn result-fn]
+  [(around (list-on-request query-fn) (list-on-response result-fn))
+   interceptors/query-interceptor])
+
+
 ;;; CREATE + UPDATE
 (defn- entity-on-request [id-key params->entity-fn]
   (fn [{:keys [request] :as ctx}]

--- a/src/main/cheffy/routes.clj
+++ b/src/main/cheffy/routes.clj
@@ -31,7 +31,7 @@
    ;;      http://localhost:3001/recipes
    #{{:app-name :cheffy ::http/scheme :http ::http/host "localhost"}
      ;; now define the routes themselves
-     ["/recipes" :get recipes-i/list-recipes-response :route-name :list-recipes]
+     ["/recipes" :get recipes-i/list-recipes :route-name :list-recipes]
      ["/recipes" :post recipes-i/upsert-recipe :route-name :create-recipe]
      ["/recipes/:recipe-id" :get recipes-i/retrieve-recipe :route-name :get-recipe]
      ["/recipes/:recipe-id" :put recipes-i/upsert-recipe :route-name :update-recipe]

--- a/src/test/cheffy/recipes_test.clj
+++ b/src/test/cheffy/recipes_test.clj
@@ -19,18 +19,7 @@
     (is (uuid? recipe-id))
     recipe-id))
 
-(deftest recipes-test
-  (testing "list recipes"
-    (testing "with auth -- public and drafts"
-      (let [{:keys [body]} (tu/assert-response-body 200
-                                                    :get "/recipes"
-                                                    :headers tu/default-headers)]
-        (is (vector? (get body "public")))
-        (is (vector? (get body "drafts")))))
-    (testing "without auth -- only public "
-      (let [{:keys [body]} (tu/assert-response-body 200 :get "/recipes")]
-        (is (vector? (get body "public")))
-        (is (nil? (get body "drafts"))))))
+(deftest recipes-crud-test
   (testing "create recipe"
     (let [recipe-id (create-recipe)]
       (reset! recipe-id-store recipe-id)))
@@ -48,3 +37,15 @@
   (testing "delete recipe"
     (tu/delete-entity (str "/recipes/" @recipe-id-store))))
 
+
+(deftest list-recipes-test
+  (testing "list recipes with auth -- public and drafts"
+    (let [{:keys [body]} (tu/assert-response-body 200
+                                                  :get "/recipes"
+                                                  :headers tu/default-headers)]
+      (is (not-empty (get body :public)))
+      (is (not-empty (get body :drafts)))))
+  (testing "list recipes without auth -- only public "
+    (let [{:keys [body]} (tu/assert-response-body 200 :get "/recipes")]
+      (is (not-empty (get body :public)))
+      (is (not (contains? body :drafts))))))


### PR DESCRIPTION
`list-recipes-query` is the core piece now encapsulating the query for both public recipes and drafts.

As such it's a bit complicated: 
```
(defn- list-recipes-query [request]
  (let [account-id (get-in request [:headers "authorization"])
        base-query '[:find (pull ?e pattern)
                     :in $ pattern]]
    ;; Or clauses: https://docs.datomic.com/on-prem/query/query.html#or-clauses
    ;; `or-join` is needed because the second clause (`and`) uses a different set of variables (`?owner`)
    ;; Note: The fact that ?account-id can be nil complicates this.
    ;; When it's nil, we have to leave out the entire owner filtering clause
    {:query (if account-id
              (conj base-query
                    '?account-id
                    :where '[or-join [?e]
                             [?e :recipe/public? true]
                             (and [?e :recipe/public? false]
                                  [?owner :account/account-id ?account-id]
                                  [?e :recipe/owner ?owner])])
              (conj base-query :where '[?e :recipe/public? true]))
     :args (cond-> [recipe-pattern]
             account-id (conj account-id))}))
```