### PR TITLE
Lesson 47 + 48: List messages & tests.

### DIFF
--- a/src/main/cheffy/conversations.clj
+++ b/src/main/cheffy/conversations.clj
@@ -31,7 +31,8 @@
   [account-id entity-id {:keys [to message-body] :as _params}]
   (let [from-ref [:account/account-id account-id]
         to-ref [:account/account-id to]
-        message-id (random-uuid)]
+        message-id (random-uuid)
+        now (java.util.Date.)]
     [#:conversation{:conversation-id entity-id
                     :participants [from-ref to-ref]
                     ;; Note: we really need to call `str` on message-id, otherwise we get a nasty error:
@@ -43,7 +44,7 @@
                ;; TODO: what does read-by really mean?
                :read-by [from-ref]
                :body message-body
-               :created-at (java.util.Date.)}]))
+               :created-at now}]))
 
 (def create-message (crud/upsert id-key params->entity))
 


### PR DESCRIPTION
I already had this implemented in a slightly different way,
that is as a GET of the whole conversation entity
which contains `:conversation/messages`.

Here's an example response I can get: 
```
{:db/id 17592186046089,
 :conversation/conversation-id #uuid "ba6dcd6e-2f94-4b10-84b6-fe0c6bacc8c2",
 :conversation/messages
 [{:db/id 17592186046090,
   :message/message-id #uuid "1cff942f-d95e-4e71-9a97-c3440b3314a6",
   :message/body "Hello, Mike!",
   :message/owner #:db{:id 17592186045418},
   :message/created-at #inst "2022-09-02T06:21:53.140-00:00",
   :message/read-by [#:db{:id 17592186045418}]}],
 :conversation/participants [#:db{:id 17592186045418} #:db{:id 17592186045419}]}#function[io.pedestal.http.impl.servlet-interceptor/interceptor-service-fn/fn--22436]
```