### PR TITLE
Lesson 49 + 50: Clear notifications + tests.

### DIFF
--- a/src/main/cheffy/crud.clj
+++ b/src/main/cheffy/crud.clj
@@ -39,11 +39,13 @@
   [(around (list-on-request query-fn) (list-on-response result-fn))
    interceptors/query-interceptor])
 
+(defn get-account-id [ctx]
+  (get-in ctx [:request :headers "authorization"]))
 
 ;;; CREATE + UPDATE
 (defn- entity-on-request [id-key params->entity-fn]
   (fn [{:keys [request] :as ctx}]
-    (let [account-id (get-in request [:headers "authorization"])
+    (let [account-id (get-account-id ctx)
           entity-id (or (some-> (get-in request [:path-params (simple-id id-key)]) parse-uuid)
                         (random-uuid))
           entities (params->entity-fn account-id entity-id (:transit-params request))]

--- a/src/main/cheffy/interceptors.clj
+++ b/src/main/cheffy/interceptors.clj
@@ -27,7 +27,7 @@
    {:name ::db-interceptor
     :enter inject-db}))
 
-(defn- transact!
+(defn transact!
   [{:keys [tx-data] :as ctx}]
   (log/debug :transact tx-data)
   #_(def my-ctx ctx)
@@ -41,7 +41,7 @@
     (do (log/warn :tx-result "no result!")
         ctx)))
 
-(defn- query!
+(defn query!
   [{:keys [q-data] :as ctx}]
   (log/debug :q-data q-data :database (database ctx))
   (let [q-with-db (update q-data :args #(into [(database ctx)] %))]

--- a/src/main/cheffy/routes.clj
+++ b/src/main/cheffy/routes.clj
@@ -58,6 +58,7 @@
      ;; because it fits my framework better - see `crud/upsert` implementation
      ["/conversations/:conversation-id" :put conversations/create-message :route-name :create-message-for-conversation]
      ["/conversations/:conversation-id" :get conversations/retrieve-message :route-name :get-message]
+     ["/conversations/:conversation-id" :delete conversations/clear-notifications :route-name :clear-notifications]
 
 
      }))

--- a/src/test/cheffy/conversations_test.clj
+++ b/src/test/cheffy/conversations_test.clj
@@ -11,24 +11,30 @@
 
 (def conversation-id-store (atom nil))
 
-(defn create-message []
-  (let [{:keys [conversation-id] :as message} (tu/create-entity "/conversations"
-                                                                {:to "mike@mailinator.com"
-                                                                 :message-body "Hello, Mike!"})]
-    (is (uuid? conversation-id))
-    message))
+(defn create-message
+  "Create message for a completely new conversation or for existing conversation."
+  ([]
+   (let [{:keys [conversation-id] :as message}
+         (tu/create-entity "/conversations"
+                           {:to "mike@mailinator.com"
+                            :message-body "Hello, Mike!"})]
+     (is (uuid? conversation-id))
+     message))
+  ([conversation-id]
+   (let [{:conversation/keys [conversation-id] :as message}
+         (tu/update-entity (str "/conversations/" conversation-id)
+                           {:to "mike@mailinator.com"
+                            :message-body "Second message, Mike!"})]
+     (is (uuid? conversation-id))
+     message)))
 
 (deftest create-messages-test
   (testing "create message for new conversation"
     (reset! conversation-id-store (:conversation-id (create-message))))
-  (testing "create message for existing conversation"
-    ;; Note: I use :put for creating messages for existing conversations,
+  (testing "create message for existing conversation" ;; Note: I use :put for creating messages for existing conversations,
     ;; because it fits my framework better - see `crud/upsert` implementation
     ;; For this to work, we also need to implement get-entity operation for conversations
-    (let [{:conversation/keys [conversation-id] :as entity} (tu/update-entity (str "/conversations/" @conversation-id-store)
-                                                                              {:to "mike@mailinator.com"
-                                                                               :message-body "Second message, Mike!"})]
-      (is (uuid? conversation-id)))))
+    (create-message @conversation-id-store)))
 
 (deftest list-messages-test
   (testing "list messages for given conversation id"
@@ -38,3 +44,20 @@
       (is (= ["Hello, Mike!"]
              (mapv :message/body
                    (:conversation/messages conversation)))))))
+
+(deftest clear-notifications-test
+  (let [{:keys [conversation-id]} (create-message)
+        _ (create-message conversation-id)
+        ;; clear notifications
+        _ (tu/assert-response 204
+                              :delete
+                              (str "/conversations/" conversation-id)
+                              ;; we must pass different account id here to clear notifications for Mike (account_2),
+                              ;; not for the conversation owner (account_1) - check seed.edn
+                              :headers (assoc tu/default-headers
+                                              "Authorization" "mike@mailinator.com"))
+        ;; and list messages to ...
+        {:conversation/keys [messages participants]} (tu/get-entity (str "/conversations/" conversation-id))]
+    ;; ... check that all the participants are listed in `:message/read-by`
+    (is (= (set participants)
+           (set (mapcat :message/read-by messages))))))


### PR DESCRIPTION
This implements DELETE on `/conversations/<conversation-id>` such that
it marks all messages in given conversation as read-by the account id set in the Authorization header.
This effectively means "clearing notifications" for the account.

This DELETE operation is special (doesn't really remove any entity) so we cannot reuse `crud/delete`.
Instead, we implement custom operation that first calls `find-unread-messages`,
then adds the request account id to `:message/read-by` attribute's value.

`find-unread-messages` is unlike all the other operations in route handlers,
in that it has to query the db directly, instead of delegating to _interceptors_.
This is done by exposing `interceptors/query!` as a public function.