### PR TITLE
Add auth component and calculate-secret-hash

### DIFF
--- a/src/config/development.edn
+++ b/src/config/development.edn
@@ -19,4 +19,10 @@
 
             :storage-dir :mem ; only needed for dev-local
             :system "dev" ; in the video they used "api.learnpedestal.com"
-            :db-name "learn-pedestal-development"}}
+            :db-name "learn-pedestal-development"}
+ ;; see https://us-east-1.console.aws.amazon.com/cognito/v2/idp/user-pools/us-east-1_naCTUkfCg/app-integration/clients/60c14ln0t3saa1jg2e0q13oj2v?region=us-east-1
+ :auth {:client-id "60c14ln0t3saa1jg2e0q13oj2v"
+        ;; TODO: replace with proper secret but make sure it's not committed
+        :client-secret "CLIENT_SECRET"
+        ;; see https://us-east-1.console.aws.amazon.com/cognito/v2/idp/user-pools?region=us-east-1
+        :user-pool-id "us-east-1_naCTUkfCg"}}

--- a/src/dev/dev.clj
+++ b/src/dev/dev.clj
@@ -512,3 +512,9 @@
                             #:account{:account-id "jade@mailinator.com", :display-name "Jade"}}]}]]
 
   ..)
+
+;; 56: Adding auth component
+(comment
+  (-> cr/system :auth :config :client-id)
+  ;; => "60c14ln0t3saa1jg2e0q13oj2v"
+  .)

--- a/src/main/cheffy/cognito.clj
+++ b/src/main/cheffy/cognito.clj
@@ -28,23 +28,27 @@
 ;;  profile-region-provider
 ;;  instance-region-provider
 
-(def cognito (aws/client {:api :cognito-idp
-                          :credentials-provider (credentials/profile-credentials-provider my-aws-profile)
-                          ;; specify region explicitly just in case
-                          ;; if you don't do this, then :region-provider is used,
-                          ;; which by default is `cognitect.aws.region/default-region-provider` (see above)
-                          ;; - for some reason, it wasn't working properly for me (probably using eu-west-1 or something else)
-                          :region "us-east-1"}))
+(defn make-client []
+  (let [cognito (aws/client {:api :cognito-idp
+                            :credentials-provider (credentials/profile-credentials-provider my-aws-profile)
+                            ;; specify region explicitly just in case
+                            ;; if you don't do this, then :region-provider is used,
+                            ;; which by default is `cognitect.aws.region/default-region-provider` (see above)
+                            ;; - for some reason, it wasn't working properly for me (probably using eu-west-1 or something else)
+                            :region "us-east-1"})]
+    (aws/validate-requests cognito true)
+    cognito))
 
 ;; enable spec checking on invoke calls - those will throw a spec error if the request is invalid
-(aws/validate-requests cognito true)
+
 
 
 ;; play with aws-api
 (comment
 
+  (def my-cognito (make-client))
   (filterv (fn [[op details]] (str/includes? (str/lower-case (name op)) "signup"))
-           (aws/ops cognito))
+           (aws/ops my-cognito))
   ;;=>
   ;; [[:SignUp
   ;; {:name "SignUp",
@@ -69,13 +73,13 @@
   ;; ...
 
   ;; get the docs printed in the repl
-  (aws/doc cognito :SignUp)
+  (aws/doc my-cognito :SignUp)
   ;; ...
   ;; Required
   ;; [:ClientId :Username :Password]
   ;; ...
 
-  (-> (aws/invoke cognito
+  (-> (aws/invoke my-cognito
                {:op :SignUp
                 ;; look here to find the client information: https://us-east-1.console.aws.amazon.com/cognito/v2/idp/user-pools/us-east-1_naCTUkfCg/app-integration/clients/60c14ln0t3saa1jg2e0q13oj2v?region=us-east-1
                 :request {:ClientId "60c14ln0t3saa1jg2e0q13oj2v"
@@ -98,7 +102,7 @@
   ;;=> solved by passing :region "us-east-1" when constructing the client
 
   ;; now try again
-  (aws/invoke cognito
+  (aws/invoke my-cognito
               {:op :SignUp
                ;; look here to find the client information: https://us-east-1.console.aws.amazon.com/cognito/v2/idp/user-pools/us-east-1_naCTUkfCg/app-integration/clients/60c14ln0t3saa1jg2e0q13oj2v?region=us-east-1
                :request {:ClientId "60c14ln0t3saa1jg2e0q13oj2v"
@@ -127,8 +131,8 @@
 ;; => "5ux0qdUfS0vc3w2hpZzIhskFDmFJhbLBxvsFJM4X1Us="
 
   (let [client-id "60c14ln0t3saa1jg2e0q13oj2v"
-        client-secret "XXX"]
-    (aws/invoke cognito
+        client-secret "xxx"]
+    (aws/invoke my-cognito
                 {:op :SignUp
                  ;; look here to find the client information: https://us-east-1.console.aws.amazon.com/cognito/v2/idp/user-pools/us-east-1_naCTUkfCg/app-integration/clients/60c14ln0t3saa1jg2e0q13oj2v?region=us-east-1
                  :request {:ClientId client-id

--- a/src/main/cheffy/components/auth.clj
+++ b/src/main/cheffy/components/auth.clj
@@ -1,0 +1,17 @@
+(ns cheffy.components.auth
+  "Authentication component using AWS Cognito."
+  (:require
+   [cheffy.cognito :as cognito]
+   [com.stuartsierra.component :as component]))
+
+(defrecord Auth [config cognito-idp]
+  component/Lifecycle
+  (start [this]
+    (println "Starting Auth...")
+    (assoc this :cognito-idp (cognito/make-client)))
+  (stop [this]
+    (println "Stopping Auth...")
+    (assoc this :cognito-idp nil)))
+
+(defn make-auth-service [auth-config]
+  (map->Auth {:config auth-config}))

--- a/src/main/cheffy/server.clj
+++ b/src/main/cheffy/server.clj
@@ -3,13 +3,15 @@
    [cheffy.components.api-server :as api-server]
    [cheffy.components.database :as database]
    [clojure.edn :as edn]
-   [com.stuartsierra.component :as component]))
+   [com.stuartsierra.component :as component]
+   [cheffy.components.auth :as auth]))
 
 (defn create-system [config]
   (component/system-map
    :config config
    :api-server (component/using (api-server/make-api-server (:service-map config))
-                               [:database])
+                                [:database])
+   :auth (auth/make-auth-service (:auth config))
    :database (database/make-db (:database config))))
 
 ;; define main method to be able to start our server

--- a/src/main/cheffy/util/crypto.clj
+++ b/src/main/cheffy/util/crypto.clj
@@ -1,0 +1,24 @@
+(ns cheffy.util.crypto
+  "Encryption and hashing utilities."
+  (:import
+   (java.util Base64)
+   (javax.crypto Mac)
+   (javax.crypto.spec SecretKeySpec)))
+
+(defn hmac-sha256-base64
+  "Signs given string using HMACSHA256 algorithm initializing it with `secret`.
+  and returning the result as Base64 encoded string (URL safe variant with no padding ??).
+  Needed for example for AWS Cognito to compute SecretHash.
+  See https://docs.aws.amazon.com/cognito/latest/developerguide/signing-up-users-in-your-app.html#cognito-user-pools-computing-secret-hash"
+  [secret s]
+  (let [alg "HmacSHA256"
+        signing-key (SecretKeySpec. (.getBytes secret) alg)
+        mac (doto (Mac/getInstance alg)
+               (.init signing-key))
+        raw-hmac (.doFinal mac (.getBytes s))]
+    (.encodeToString (Base64/getEncoder) raw-hmac)))
+
+(comment
+  (hmac-sha256-base64 "mysecret" "mystring")
+  ;; => "7K9NIoCpt56WlhVKiWSeAyAVwoyjulqQLG66FFrhEAE="
+  .)


### PR DESCRIPTION
This produced HmacSHA256 signature of username + client-id needed for aws cognito.
See
https://docs.aws.amazon.com/cognito/latest/developerguide/signing-up-users-in-your-app.html#cognito-user-pools-computing-secret-hash

We simply use java interop:
```
(defn hmac-sha256-base64
  "Signs given string using HMACSHA256 algorithm initializing it with `secret`.
  and returning the result as Base64 encoded string (URL safe variant with no padding ??).
  Needed for example for AWS Cognito to compute SecretHash.
  See https://docs.aws.amazon.com/cognito/latest/developerguide/signing-up-users-in-your-app.html#cognito-user-pools-computing-secret-hash"
  [secret s]
  (let [alg "HmacSHA256"
        signing-key (SecretKeySpec. (.getBytes secret) alg)
        mac (doto (Mac/getInstance alg)
               (.init signing-key))
        raw-hmac (.doFinal mac (.getBytes s))]
    (.encodeToString (Base64/getEncoder) raw-hmac)))
```