### PR TITLE
59. Confirm account

### DIFF
--- a/src/main/cheffy/account.clj
+++ b/src/main/cheffy/account.clj
@@ -1,5 +1,6 @@
 (ns cheffy.account
   (:require
+   [cheffy.components.auth :as auth]
    [cheffy.interceptors :as interceptors]
    [io.pedestal.interceptor.helpers :refer [around]]
    [ring.util.response :as response]))

--- a/src/main/cheffy/account.clj
+++ b/src/main/cheffy/account.clj
@@ -5,7 +5,7 @@
    [io.pedestal.interceptor.helpers :refer [around]]
    [ring.util.response :as response]))
 
-(defn on-request [{:keys [request] :as ctx}]
+(defn on-signup-request [{:keys [request] :as ctx}]
   (let [{:keys [system/auth transit-params]} request
         {:keys [email password]} transit-params
         account-result (auth/create-cognito-account auth
@@ -14,9 +14,19 @@
     (assoc ctx :tx-data [{:account/account-id (:UserSub account-result)
                           :account/display-name email}])))
 
-(defn on-response [ctx]
+(defn on-signup-response [ctx]
   (let [account-id (-> ctx :tx-data first :account/account-id)]
     (assoc ctx :response (response/response {:account-id account-id}))))
 
-(def sign-up  [(around ::sign-up-interceptor on-request on-response)
+(def sign-up  [(around ::sign-up-interceptor on-signup-request on-signup-response)
                interceptors/transact-interceptor])
+
+(defn on-confirm-request [{:keys [request] :as ctx}]
+  (let [{:keys [system/auth transit-params]} request]
+    (auth/confirm-account auth transit-params)
+    ctx))
+
+(defn on-confirm-response [ctx]
+  (assoc ctx :response (response/status 204)))
+
+(def confirm [(around ::confirm-account-interceptor on-confirm-request on-confirm-response)])

--- a/src/main/cheffy/components/auth.clj
+++ b/src/main/cheffy/components/auth.clj
@@ -3,7 +3,8 @@
   (:require
    [cheffy.cognito :as cognito]
    [cognitect.aws.client.api :as aws]
-   [com.stuartsierra.component :as component]))
+   [com.stuartsierra.component :as component]
+   [clojure.string :as str]))
 
 (defrecord Auth [config cognito-idp]
   component/Lifecycle
@@ -31,3 +32,49 @@
                                                                                   :username email})}})]
     (when (contains? result :cognitect.anomalies/category)
       (throw (ex-info "Create cognito account failed" result)))))
+
+(defn confirm-account
+  [{:keys [config cognito-idp] :as _auth}
+   {:keys [email confirmation-code] :as _params}]
+  (let [{:keys [client-id client-secret]} config
+        ;; result will be `{}` if all is ok
+        result (aws/invoke cognito-idp
+                           {:op :ConfirmSignUp
+                            :request {:ClientId client-id
+                                      :Username email
+                                      :ConfirmationCode confirmation-code
+                                      :SecretHash (cognito/calculate-secret-hash {:client-id client-id
+                                                                                  :client-secret client-secret
+                                                                                  :username email})}})]
+    (when (contains? result :cognitect.anomalies/category)
+      (throw (ex-info "Create cognito account failed" result)))))
+
+(comment
+
+  (def my-cognito (cognito/make-client))
+
+  ;; try to search for some 'confirm' operation
+  (keep (fn [[k v]]
+          (when (-> k name str/lower-case (str/includes? "confirm"))
+            k))
+          (aws/ops my-cognito))
+;; => (:AdminConfirmSignUp :ConfirmSignUp :ConfirmForgotPassword :ResendConfirmationCode :ConfirmDevice)
+
+  ;; ConfirmSignUp looks like the thing we want to do
+  (aws/doc my-cognito :ConfirmSignUp)
+  ;;=> needs :ConfirmationCode (see your email: https://mail.google.com/mail/u/0/?zx=vb7xkb7gywyc#inbox/FMfcgzGqQmMRxrxQkPCTsrFnnFtMHNfn)
+
+  (let [client-id "60c14ln0t3saa1jg2e0q13oj2v"
+        ;; see https://us-east-1.console.aws.amazon.com/cognito/v2/idp/user-pools/us-east-1_naCTUkfCg/app-integration/clients/60c14ln0t3saa1jg2e0q13oj2v?region=us-east-1
+        client-secret "xxx"
+        username "jumarko+cheffy@gmail.com"
+        ;; code must be string
+        confirmation-code "843367"]
+    (confirm-account {:config {:client-id client-id
+                               :client-secret client-secret}
+                      :cognito-idp my-cognito}
+                     {:email username
+                      :confirmation-code confirmation-code}))
+  
+
+  .)

--- a/src/main/cheffy/routes.clj
+++ b/src/main/cheffy/routes.clj
@@ -34,6 +34,7 @@
 
      ;; accounts routes
      ["/account/sign-up" :post account/sign-up :route-name :sign-up]
+     ["/account/confirm" :post account/confirm :route-name :sign-up]
 
      ;; recipes routes
      ["/recipes" :get recipes-i/list-recipes :route-name :list-recipes]


### PR DESCRIPTION
This adds a new function auth/confirm-account and related route /account/confirm.

We'll call Cognito's API to confirm an account that was previously signed up via auth/create-cognito-account

Tangential piece that's interesting - how to find proper cognito API operation: 

```
  (def my-cognito (cognito/make-client))

  ;; try to search for some 'confirm' operation
  (keep (fn [[k v]]
          (when (-> k name str/lower-case (str/includes? "confirm"))
            k))
          (aws/ops my-cognito))
;; => (:AdminConfirmSignUp :ConfirmSignUp :ConfirmForgotPassword :ResendConfirmationCode :ConfirmDevice)
```